### PR TITLE
refactor: зависимость только от IController

### DIFF
--- a/include/core/ControllerImpl.h
+++ b/include/core/ControllerImpl.h
@@ -3,7 +3,7 @@
 #include "interfaces/IController.h"
 #include "interfaces/IModel.h"
 
-class ControllerImpl: public IController
+class ControllerImpl: public IController, public std::enable_shared_from_this<ControllerImpl>
 {
 public:
 	explicit ControllerImpl(IModel::Ptr model);

--- a/include/interfaces/IController.h
+++ b/include/interfaces/IController.h
@@ -68,8 +68,11 @@ public:
     /*!
      * \brief Shared pointer type for IController.
      */
-    using Ptr = std::shared_ptr<IController>;
+    using Ptr = std::shared_ptr<const IController>;
 };
+
+IController::Ptr createInstance();
+
 #include <SDL.h>
 
 #include <SDL_vulkan.h>

--- a/src/core/ControllerImpl.cpp
+++ b/src/core/ControllerImpl.cpp
@@ -6,6 +6,7 @@
 #include "core/ControllerImpl.h"
 
 #define GLM_ENABLE_EXPERIMENTAL
+#include <core/View.h>
 #include <glm/gtx/transform.hpp>
 
 ControllerImpl::ControllerImpl(IModel::Ptr model)
@@ -24,12 +25,6 @@ double getCurrentGlobalTime() {
 
     // Return the double value
     return seconds.count();
-}
-
-void createCubes(const std::shared_ptr<IModel> &_model) {
-    for (int i = 0; i < 5; i++) {
-        _model->createMesh("cube" + i);
-    }
 }
 
 void updateCube(const std::shared_ptr<IModel> &_model, int name) {
@@ -63,6 +58,7 @@ void ControllerImpl::processEvent(SDL_Event &e) const {
 }
 
 void ControllerImpl::init() const {
-
-    createCubes(_model);
+    const auto controller = shared_from_this();
+    const auto view = createView(controller, _model);
+    view->run();
 }

--- a/src/core/ViewImpl.cpp
+++ b/src/core/ViewImpl.cpp
@@ -36,13 +36,17 @@ ViewImpl::ViewImpl(IController::Ptr controller, IModel::Ptr model) : _controller
             window_flags);
 }
 
+void createCubes(const std::shared_ptr<IModel> &_model) {
+    for (int i = 0; i < 5; i++) {
+        _model->createMesh("cube" + i);
+    }
+}
 
 void ViewImpl::run() const {
 
     _model->registerWindow(window);
 
-
-    _controller->init();
+    createCubes(_model);
 
     SDL_Event e;
     bool bQuit = false;

--- a/src/core/createInstance.cpp
+++ b/src/core/createInstance.cpp
@@ -1,0 +1,11 @@
+#include "interfaces/IController.h"
+#include "interfaces/IModel.h"
+#include "core/Controller.h"
+#include "core/Model.h"
+
+IController::Ptr createInstance()
+{
+	const auto model = createModel();
+	const auto controller = createController(model);
+	return controller;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,18 +1,13 @@
 ﻿#include <iostream>
 
-#include "core/Controller.h"
-#include "core/Model.h"
-#include "core/View.h"
+#include "interfaces/IController.h"
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char* args[])
 {
 	try
 	{
-		auto const model = createModel();
-		auto const controller = createController(model);
-		auto const view = createView(controller, model);
-
-		view->run();
+		const auto controller = createInstance();
+		controller->init();
 	} catch (std::runtime_error const& e)
 	{
 		std::cerr << "Unhandled exception: " << e.what() << '\n';


### PR DESCRIPTION
- Теперь для подключения библиотеки достаточно подключить только интерфейс контроллера.

- Вероятно, костыль: для сохранения взаимодействия объектов пришлось наследовать ControllerImpl от std::enable_shared_from_this<T>.