### PR TITLE
Добавление флагов компиляции

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required (VERSION 3.14)
+﻿cmake_minimum_required (VERSION 3.24)
 
 project ("renderlib")
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,9 @@
       "installDir": "${sourceDir}/out/install/${presetName}",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "cl",
-        "CMAKE_CXX_COMPILER": "cl"
+        "CMAKE_CXX_COMPILER": "cl",
+        "CMAKE_C_FLAGS_INIT": "/W4",
+        "CMAKE_CXX_FLAGS_INIT": "/W4"
       },
       "condition": {
         "type": "equals",
@@ -67,7 +69,9 @@
       "installDir": "${sourceDir}/out/install/${presetName}",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "clang",
-        "CMAKE_CXX_COMPILER": "clang++"
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_C_FLAGS_INIT": "-Werror -Wall -Wextra -pedantic -Wconversion -Wdouble-promotion -Wshadow",
+        "CMAKE_CXX_FLAGS_INIT": "-Werror -Wall -Wextra -pedantic -Wconversion -Wdouble-promotion -Wshadow"
       },
       "condition": {
         "type": "equals",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,6 +10,7 @@
       "cacheVariables": {
         "CMAKE_C_COMPILER": "cl",
         "CMAKE_CXX_COMPILER": "cl",
+        "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
         "CMAKE_C_FLAGS_INIT": "/W4",
         "CMAKE_CXX_FLAGS_INIT": "/W4"
       },
@@ -70,8 +71,9 @@
       "cacheVariables": {
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
-        "CMAKE_C_FLAGS_INIT": "-Werror -Wall -Wextra -pedantic -Wconversion -Wdouble-promotion -Wshadow",
-        "CMAKE_CXX_FLAGS_INIT": "-Werror -Wall -Wextra -pedantic -Wconversion -Wdouble-promotion -Wshadow"
+        "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
+        "CMAKE_C_FLAGS_INIT": "-Wall -Wextra -pedantic -Wconversion -Wdouble-promotion -Wshadow",
+        "CMAKE_CXX_FLAGS_INIT": "-Wall -Wextra -pedantic -Wconversion -Wdouble-promotion -Wshadow"
       },
       "condition": {
         "type": "equals",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,15 +2,24 @@
   "version": 3,
   "configurePresets": [
     {
-      "name": "windows-base",
+      "name": "base",
       "hidden": true,
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/out/build/${presetName}",
       "installDir": "${sourceDir}/out/install/${presetName}",
       "cacheVariables": {
+        "CMAKE_COMPILE_WARNING_AS_ERROR": "ON"
+      },
+      "toolchainFile": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+    },
+
+    {
+      "name": "windows-base",
+      "hidden": true,
+      "inherits": "base",
+      "cacheVariables": {
         "CMAKE_C_COMPILER": "cl",
         "CMAKE_CXX_COMPILER": "cl",
-        "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
         "CMAKE_C_FLAGS_INIT": "/W4",
         "CMAKE_CXX_FLAGS_INIT": "/W4"
       },
@@ -18,8 +27,7 @@
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
-      },
-      "toolchainFile": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+      }
     },
 
     {
@@ -65,13 +73,10 @@
     {
       "name": "linux-base",
       "hidden": true,
-      "generator": "Ninja",
-      "binaryDir": "${sourceDir}/out/build/${presetName}",
-      "installDir": "${sourceDir}/out/install/${presetName}",
+      "inherits": "base",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
-        "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
         "CMAKE_C_FLAGS_INIT": "-Wall -Wextra -pedantic -Wconversion -Wdouble-promotion -Wshadow",
         "CMAKE_CXX_FLAGS_INIT": "-Wall -Wextra -pedantic -Wconversion -Wdouble-promotion -Wshadow"
       },
@@ -79,8 +84,7 @@
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Linux"
-      },
-      "toolchainFile": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+      }
     },
     {
       "name": "lx64-debug",


### PR DESCRIPTION
Сделано:
- Флаги компиляции были добавлены в пресеты. По умолчанию предупреждение - это ошибка (флаг выставлен через переменную CMake - [CMAKE_COMPILE_WARNING_AS_ERROR](https://cmake.org/cmake/help/latest/variable/CMAKE_COMPILE_WARNING_AS_ERROR.html#cmake-compile-warning-as-error) - для этого повысил минимальную версию до 3.24, попутно решив проблему с несоответствием мин. версии с версией файла описания пресетов и find_package).
- Теперь пресеты для windows и linux наследуются от одного пресета base - стало меньше повторений строчек.