### PR TITLE
Fixed the shader build script

### DIFF
--- a/cmake/compileShaders.cmake
+++ b/cmake/compileShaders.cmake
@@ -1,20 +1,6 @@
 set(BUILD_SHADERS_SCRIPT "${CMAKE_SOURCE_DIR}/scripts/build_shaders.py")
 
-set(SHADERS_SOURCE_DIR "${CMAKE_SOURCE_DIR}/shaders")
-set(SHADERS_DEST_DIR "${CMAKE_BINARY_DIR}/shaders")
-
 add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
-        COMMAND ${CMAKE_COMMAND} -E echo "Running build_shaders.py script..."
-        COMMAND ${CMAKE_COMMAND} -E env PROJECTDIR=${CMAKE_SOURCE_DIR} python ${BUILD_SHADERS_SCRIPT}
-        COMMENT "Running build_shaders.py")
-
-file(GLOB SPV_SHADERS "${SHADERS_SOURCE_DIR}/*.spv")
-
-foreach(SPV_FILE ${SPV_SHADERS})
-    get_filename_component(SPV_FILENAME ${SPV_FILE} NAME)
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E echo "Copying ${SPV_FILENAME} to build directory..."
-            COMMAND ${CMAKE_COMMAND} -E copy
-            ${SPV_FILE} ${SHADERS_DEST_DIR}/${SPV_FILENAME}
-            COMMENT "Copying ${SPV_FILENAME} to build directory")
-endforeach()
+    COMMAND ${CMAKE_COMMAND} -E echo "Running build_shaders.py script..."
+    COMMAND ${CMAKE_COMMAND} -E env PROJECTDIR=${CMAKE_SOURCE_DIR} python ${BUILD_SHADERS_SCRIPT}
+    COMMENT "Running build_shaders.py")

--- a/cmake/compileShaders.cmake
+++ b/cmake/compileShaders.cmake
@@ -1,6 +1,10 @@
 set(BUILD_SHADERS_SCRIPT "${CMAKE_SOURCE_DIR}/scripts/build_shaders.py")
+set(SHADERS_SOURCE_DIR "${CMAKE_SOURCE_DIR}/shaders")
+set(SHADERS_DEST_DIR "${CMAKE_BINARY_DIR}/shaders")
 
 add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
-    COMMAND ${CMAKE_COMMAND} -E echo "Running build_shaders.py script..."
-    COMMAND ${CMAKE_COMMAND} -E env PROJECTDIR=${CMAKE_SOURCE_DIR} python ${BUILD_SHADERS_SCRIPT}
-    COMMENT "Running build_shaders.py")
+        COMMAND ${CMAKE_COMMAND} -E echo "Running build_shaders.py script..."
+        COMMAND python ${BUILD_SHADERS_SCRIPT} 
+                ${SHADERS_SOURCE_DIR}
+                ${SHADERS_DEST_DIR}
+        COMMENT "Running build_shaders.py")

--- a/scripts/build_shaders.py
+++ b/scripts/build_shaders.py
@@ -1,49 +1,32 @@
 import os
 import subprocess
-import shutil
+import argparse
 
+def main():
+    parser = argparse.ArgumentParser(description='Compile GLSL shaders to SPIR-V')
+    parser.add_argument('source_dir', help='Directory containing source shader files')
+    parser.add_argument('output_dir', help='Directory for compiled shader output')
+    args = parser.parse_args()
 
-project_dir = os.environ.get('PROJECTDIR')
-if not project_dir:
-    raise ValueError("Environment variable PROJECTDIR is not set")
+    # Ensure output directory exists
+    os.makedirs(args.output_dir, exist_ok=True)
 
+    # Select appropriate glslc executable based on platform
+    glslc_executable = "glslc.exe" if os.name == 'nt' else "glslc"
 
-if os.name == 'nt':
-    glslc_executable = "glslc.exe"
-else:
-    glslc_executable = "glslc"
+    print(f"Compiling shaders from {args.source_dir} to {args.output_dir}")
 
-
-shaders_source_dir = os.path.join(project_dir, "shaders")
-shaders_dest_dir = os.path.join(project_dir, "build", "shaders")
-
-
-os.makedirs(shaders_dest_dir, exist_ok=True)
-
-print("Shader builder working directory: " + project_dir)
-
-
-for filename in os.listdir(shaders_source_dir):
-    if filename.endswith(".vert") or filename.endswith(".frag") or filename.endswith(".comp"):
-        shader_file_path = os.path.join(shaders_source_dir, filename)
-
-        
-        output_file = os.path.splitext(shader_file_path)[0] + os.path.splitext(shader_file_path)[1] + ".spv"
-
-        
-        command = [glslc_executable, shader_file_path, "-o", output_file]
-
-        try:
-           
-            subprocess.run(command, check=True)
-            print(f"Compiled {filename} to {output_file}")
-
+    for filename in os.listdir(args.source_dir):
+        if filename.endswith((".vert", ".frag", ".comp")):
+            shader_file_path = os.path.join(args.source_dir, filename)
+            output_file = os.path.join(args.output_dir, filename + ".spv")
             
-            dest_file = os.path.join(shaders_dest_dir, os.path.basename(output_file))
-            shutil.copy(output_file, dest_file)
-            print(f"Copied {output_file} to {dest_file}")
+            command = [glslc_executable, shader_file_path, "-o", output_file]
+            try:
+                subprocess.run(command, check=True)
+                print(f"Compiled {filename} to {output_file}")
+            except subprocess.CalledProcessError as e:
+                print(f"Failed to compile {filename}: {e}")
 
-        except subprocess.CalledProcessError as e:
-            print(f"Failed to compile {filename}: {e}")
-        except Exception as e:
-            print(f"Failed to copy {output_file}: {e}")
+if __name__ == "__main__":
+    main()

--- a/scripts/build_shaders.py
+++ b/scripts/build_shaders.py
@@ -1,25 +1,49 @@
 import os
 import subprocess
+import shutil
+
 
 project_dir = os.environ.get('PROJECTDIR')
+if not project_dir:
+    raise ValueError("Environment variable PROJECTDIR is not set")
+
 
 if os.name == 'nt':
     glslc_executable = "glslc.exe"
 else:
     glslc_executable = "glslc"
 
+
+shaders_source_dir = os.path.join(project_dir, "shaders")
+shaders_dest_dir = os.path.join(project_dir, "build", "shaders")
+
+
+os.makedirs(shaders_dest_dir, exist_ok=True)
+
 print("Shader builder working directory: " + project_dir)
 
-for filename in os.listdir(project_dir + "/shaders/"):
-    if filename.endswith(".vert") or filename.endswith(".frag") or filename.endswith(".comp"):
-        shader_file_path = os.path.join(project_dir + "/shaders/", filename)
 
+for filename in os.listdir(shaders_source_dir):
+    if filename.endswith(".vert") or filename.endswith(".frag") or filename.endswith(".comp"):
+        shader_file_path = os.path.join(shaders_source_dir, filename)
+
+        
         output_file = os.path.splitext(shader_file_path)[0] + os.path.splitext(shader_file_path)[1] + ".spv"
 
+        
         command = [glslc_executable, shader_file_path, "-o", output_file]
 
         try:
+           
             subprocess.run(command, check=True)
             print(f"Compiled {filename} to {output_file}")
+
+            
+            dest_file = os.path.join(shaders_dest_dir, os.path.basename(output_file))
+            shutil.copy(output_file, dest_file)
+            print(f"Copied {output_file} to {dest_file}")
+
         except subprocess.CalledProcessError as e:
             print(f"Failed to compile {filename}: {e}")
+        except Exception as e:
+            print(f"Failed to copy {output_file}: {e}")


### PR DESCRIPTION
- Moved the logic for copying compiled shaders from CMake to the Python script.
  - This simplifies the CMake configuration and centralizes shader-related logic.

- Added automatic creation of the target directory if it doesn't exist.
  - Ensures that the build process doesn't fail due to missing directories.

- Simplified the CMake script by removing redundant copy commands.
  - The Python script now handles all file operations, reducing CMake complexity.

- Updated `cmake/compileShaders.cmake` to reflect the changes.
  - Removed outdated logic and aligned with the new Python-based approach.

- Added error handling for file operations to ensure robustness.
  - Improved error messages and handling for file-related issues.