### PR TITLE
chore: vcpkg update

### DIFF
--- a/src/graphics/vulkan/vk_command_buffers.cpp
+++ b/src/graphics/vulkan/vk_command_buffers.cpp
@@ -38,9 +38,9 @@ void CommandBuffers::init_commands(VulkanEngine* vk_engine) {
     VK_CHECK(vkAllocateCommandBuffers(vk_engine->_device, &cmdAllocInfo,
                                       &(vk_engine->_immCommandBuffer)));
 
-    vk_engine->_mainDeletionQueue.push_function([=, this] {
-        vkDestroyCommandPool(vk_engine->_device, vk_engine->_immCommandPool,
-                             nullptr);
+    vk_engine->_mainDeletionQueue.push_function([=] {
+    vkDestroyCommandPool(vk_engine->_device, vk_engine->_immCommandPool,
+                         nullptr);
     });
 }
 


### PR DESCRIPTION
Из-за старой версии vcpkg gperf не собирался под ubuntu. Обновление сабмодуля фиксит ci