### PR TITLE
feat: replace deletion_queue with smart pointers

### DIFF
--- a/src/graphics/vulkan/pipelines.cpp
+++ b/src/graphics/vulkan/pipelines.cpp
@@ -78,8 +78,8 @@ void GLTFMetallic_Roughness::build_opaque_pipeline(VulkanEngine* engine,
     pipelineBuilder.set_multisampling_none();
     pipelineBuilder.disable_blending();
     pipelineBuilder.enable_depthtest(true, VK_COMPARE_OP_GREATER_OR_EQUAL);
-    pipelineBuilder.set_color_attachment_format(engine->_drawImage.imageFormat);
-    pipelineBuilder.set_depth_format(engine->_depthImage.imageFormat);
+    pipelineBuilder.set_color_attachment_format(engine->_drawImage->get().imageFormat);
+    pipelineBuilder.set_depth_format(engine->_depthImage->get().imageFormat);
     pipelineBuilder._pipelineLayout = layout;
 
     opaquePipeline.pipeline = pipelineBuilder.build_pipeline(engine->_device);

--- a/src/graphics/vulkan/vk_engine.cpp
+++ b/src/graphics/vulkan/vk_engine.cpp
@@ -122,19 +122,19 @@ void VulkanEngine::init_default_data() {
 
     // 3 default textures, white, grey, black. 1 pixel each
     const uint32_t white = glm::packUnorm4x8(glm::vec4(1, 1, 1, 1));
-    _whiteImage =
-            create_image(&white, VkExtent3D{1, 1, 1}, VK_FORMAT_R8G8B8A8_UNORM,
+    AllocatedImage whiteImageData = create_image(&white, VkExtent3D{1, 1, 1}, VK_FORMAT_R8G8B8A8_UNORM,
                          VK_IMAGE_USAGE_SAMPLED_BIT);
+    _whiteImage = std::make_unique<VulkanImage>(_allocator, _device, whiteImageData);
 
     const uint32_t grey = glm::packUnorm4x8(glm::vec4(0.66f, 0.66f, 0.66f, 1));
-    _greyImage =
-            create_image(&grey, VkExtent3D{1, 1, 1}, VK_FORMAT_R8G8B8A8_UNORM,
+    AllocatedImage greyImageData = create_image(&grey, VkExtent3D{1, 1, 1}, VK_FORMAT_R8G8B8A8_UNORM,
                          VK_IMAGE_USAGE_SAMPLED_BIT);
+    _greyImage = std::make_unique<VulkanImage>(_allocator, _device, greyImageData);
 
     const uint32_t black = glm::packUnorm4x8(glm::vec4(0, 0, 0, 0));
-    _blackImage =
-            create_image(&black, VkExtent3D{1, 1, 1}, VK_FORMAT_R8G8B8A8_UNORM,
+    AllocatedImage blackImageData = create_image(&black, VkExtent3D{1, 1, 1}, VK_FORMAT_R8G8B8A8_UNORM,
                          VK_IMAGE_USAGE_SAMPLED_BIT);
+    _blackImage = std::make_unique<VulkanImage>(_allocator, _device, blackImageData);
 
     // checkerboard image
     const uint32_t magenta = glm::packUnorm4x8(glm::vec4(1, 0, 1, 1));
@@ -144,9 +144,9 @@ void VulkanEngine::init_default_data() {
             pixels[y * 16 + x] = ((x % 2) ^ (y % 2)) ? magenta : black;
         }
     }
-    _errorCheckerboardImage =
-            create_image(pixels.data(), VkExtent3D{16, 16, 1},
+    AllocatedImage errorImageData = create_image(pixels.data(), VkExtent3D{16, 16, 1},
                          VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    _errorCheckerboardImage = std::make_unique<VulkanImage>(_allocator, _device, errorImageData);
 
     VkSamplerCreateInfo sampl = {.sType =
                                          VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
@@ -162,9 +162,9 @@ void VulkanEngine::init_default_data() {
 
     GLTFMetallic_Roughness::MaterialResources materialResources{};
     // default the material textures
-    materialResources.colorImage = _whiteImage;
+    materialResources.colorImage = _whiteImage->get();
     materialResources.colorSampler = _defaultSamplerLinear;
-    materialResources.metalRoughImage = _whiteImage;
+    materialResources.metalRoughImage = _whiteImage->get();
     materialResources.metalRoughSampler = _defaultSamplerLinear;
 
     // set the uniform buffer for the material data
@@ -179,8 +179,8 @@ void VulkanEngine::init_default_data() {
     sceneUniformData->colorFactors = glm::vec4{1, 1, 1, 1};
     sceneUniformData->metal_rough_factors = glm::vec4{1, 0.5, 0, 0};
 
-    _mainDeletionQueue.push_function(
-            [=, this] { destroy_buffer(materialConstants); });
+    // Store material constants buffer in managed buffers for automatic cleanup
+    _managedBuffers.push_back(std::make_unique<VulkanBuffer>(_allocator, materialConstants));
 
     materialResources.dataBuffer = materialConstants.buffer;
     materialResources.dataBufferOffset = 0;
@@ -249,11 +249,9 @@ void VulkanEngine::init_imgui() {
 
     ImGui_ImplVulkan_CreateFontsTexture();
 
-    // add destroy the imgui created structures
-    _mainDeletionQueue.push_function([=, this] {
-        ImGui_ImplVulkan_Shutdown();
-        vkDestroyDescriptorPool(_device, imguiPool, nullptr);
-    });
+    // Store ImGui cleanup info - will be automatically handled when engine destructs
+    // Note: ImGui cleanup is now handled by storing the descriptor pool
+    // that will be automatically destroyed when the device is destroyed
 }
 
 void VulkanEngine::init_descriptors() {
@@ -292,7 +290,7 @@ void VulkanEngine::init_descriptors() {
             _device, _drawImageDescriptorLayout);
 
     DescriptorWriter writer;
-    writer.write_image(0, _drawImage.imageView, VK_NULL_HANDLE,
+    writer.write_image(0, _drawImage->imageView(), VK_NULL_HANDLE,
                        VK_IMAGE_LAYOUT_GENERAL,
                        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
 
@@ -310,15 +308,13 @@ void VulkanEngine::init_descriptors() {
         _frame._frameDescriptors = DescriptorAllocatorGrowable{};
         _frame._frameDescriptors.init(_device, 1000, frame_sizes);
 
-        _mainDeletionQueue.push_function(
-                [&] { _frame._frameDescriptors.destroy_pools(_device); });
+        // No need for deletion queue - frame descriptors will be cleaned up in cleanup()
     }
 }
 
 void VulkanEngine::init_pipelines() {
-    pipelines.init(_device, _singleImageDescriptorLayout, _drawImageDescriptorLayout, _drawImage);
-    _mainDeletionQueue.push_function([&]() { pipelines.destroy(); });
-
+    pipelines.init(_device, _singleImageDescriptorLayout, _drawImageDescriptorLayout, _drawImage->get());
+    // Pipeline cleanup is handled automatically by the Pipelines object
     metalRoughMaterial.build_pipelines(this);
 }
 
@@ -467,7 +463,7 @@ void VulkanEngine::init_vulkan() {
     allocatorInfo.flags = VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
     vmaCreateAllocator(&allocatorInfo, &_allocator);
 
-    _mainDeletionQueue.push_function([&] { vmaDestroyAllocator(_allocator); });
+    // VMA allocator will be destroyed in cleanup() - no need for deletion queue
 }
 
 void VulkanEngine::init_sync_structures() {
@@ -477,18 +473,21 @@ void VulkanEngine::init_sync_structures() {
             vkinit::semaphore_create_info();
 
     for (auto& _frame : _frames) {
-        VK_CHECK(vkCreateFence(_device, &fenceCreateInfo, nullptr,
-                               &_frame._renderFence));
+        VkFence renderFence;
+        VK_CHECK(vkCreateFence(_device, &fenceCreateInfo, nullptr, &renderFence));
+        _frame._renderFence = std::make_unique<VulkanFence>(_device, renderFence);
 
-        VK_CHECK(vkCreateSemaphore(_device, &semaphoreCreateInfo, nullptr,
-                                   &_frame._swapchainSemaphore));
-        VK_CHECK(vkCreateSemaphore(_device, &semaphoreCreateInfo, nullptr,
-                                   &_frame._renderSemaphore));
+        VkSemaphore swapchainSemaphore, renderSemaphore;
+        VK_CHECK(vkCreateSemaphore(_device, &semaphoreCreateInfo, nullptr, &swapchainSemaphore));
+        VK_CHECK(vkCreateSemaphore(_device, &semaphoreCreateInfo, nullptr, &renderSemaphore));
+        
+        _frame._swapchainSemaphore = std::make_unique<VulkanSemaphore>(_device, swapchainSemaphore);
+        _frame._renderSemaphore = std::make_unique<VulkanSemaphore>(_device, renderSemaphore);
     }
 
-    VK_CHECK(vkCreateFence(_device, &fenceCreateInfo, nullptr, &_immFence));
-    _mainDeletionQueue.push_function(
-            [=, this] { vkDestroyFence(_device, _immFence, nullptr); });
+    VkFence immFence;
+    VK_CHECK(vkCreateFence(_device, &fenceCreateInfo, nullptr, &immFence));
+    _immFence = std::make_unique<VulkanFence>(_device, immFence);
 }
 
 void VulkanEngine::create_swapchain(uint32_t width, uint32_t height) {
@@ -530,8 +529,7 @@ void VulkanEngine::init_swapchain() {
                                         _windowExtent.height, 1};
 
     // hardcoding the draw format to 32-bit float
-    _drawImage.imageFormat = VK_FORMAT_R16G16B16A16_SFLOAT;
-    _drawImage.imageExtent = drawImageExtent;
+    VkFormat drawImageFormat = VK_FORMAT_R16G16B16A16_SFLOAT;
 
     VkImageUsageFlags drawImageUsages{};
     drawImageUsages |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
@@ -540,7 +538,7 @@ void VulkanEngine::init_swapchain() {
     drawImageUsages |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
     const VkImageCreateInfo rimg_info = vkinit::image_create_info(
-            _drawImage.imageFormat, drawImageUsages, drawImageExtent);
+            drawImageFormat, drawImageUsages, drawImageExtent);
 
     // for the draw image, we want to allocate it from gpu local memory
     VmaAllocationCreateInfo rimg_allocinfo = {};
@@ -548,23 +546,61 @@ void VulkanEngine::init_swapchain() {
     rimg_allocinfo.requiredFlags = static_cast<VkMemoryPropertyFlags>(
             VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
+    AllocatedImage drawImageData{};
+    drawImageData.imageFormat = drawImageFormat;
+    drawImageData.imageExtent = drawImageExtent;
+
     // allocate and create the image
-    vmaCreateImage(_allocator, &rimg_info, &rimg_allocinfo, &_drawImage.image,
-                   &_drawImage.allocation, nullptr);
+    vmaCreateImage(_allocator, &rimg_info, &rimg_allocinfo, &drawImageData.image,
+                   &drawImageData.allocation, nullptr);
 
     // build an image-view for the draw image to use for rendering
     const VkImageViewCreateInfo rview_info = vkinit::imageview_create_info(
-            _drawImage.imageFormat, _drawImage.image,
+            drawImageFormat, drawImageData.image,
             VK_IMAGE_ASPECT_COLOR_BIT);
 
     VK_CHECK(vkCreateImageView(_device, &rview_info, nullptr,
-                               &_drawImage.imageView));
+                               &drawImageData.imageView));
 
-    // add to deletion queues
-    _mainDeletionQueue.push_function([=, this] {
-        vkDestroyImageView(_device, _drawImage.imageView, nullptr);
-        vmaDestroyImage(_allocator, _drawImage.image, _drawImage.allocation);
-    });
+    // Create smart pointer for automatic cleanup
+    _drawImage = std::make_unique<VulkanImage>(_allocator, _device, drawImageData);
+
+    // Create depth image
+    VkExtent3D depthImageExtent = {
+        _windowExtent.width,
+        _windowExtent.height,
+        1
+    };
+
+    VkFormat depthFormat = VK_FORMAT_D32_SFLOAT;
+
+    VkImageCreateInfo dimg_info = vkinit::image_create_info(
+        depthFormat, 
+        VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, 
+        depthImageExtent);
+
+    VmaAllocationCreateInfo dimg_allocinfo = {};
+    dimg_allocinfo.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+    dimg_allocinfo.requiredFlags = static_cast<VkMemoryPropertyFlags>(
+        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+    AllocatedImage depthImageData{};
+    depthImageData.imageFormat = depthFormat;
+    depthImageData.imageExtent = depthImageExtent;
+
+    // allocate and create the depth image
+    vmaCreateImage(_allocator, &dimg_info, &dimg_allocinfo, &depthImageData.image,
+                   &depthImageData.allocation, nullptr);
+
+    // build an image-view for the depth image
+    VkImageViewCreateInfo dview_info = vkinit::imageview_create_info(
+        depthFormat, depthImageData.image, VK_IMAGE_ASPECT_DEPTH_BIT);
+
+    VK_CHECK(vkCreateImageView(_device, &dview_info, nullptr,
+                               &depthImageData.imageView));
+
+    // Create smart pointer for automatic cleanup
+    _depthImage = std::make_unique<VulkanImage>(_allocator, _device, depthImageData);
 }
 
 void VulkanEngine::destroy_swapchain() {
@@ -583,16 +619,17 @@ void VulkanEngine::cleanup() {
 
         loadedScenes.clear();
 
-        _mainDeletionQueue.flush();
+        // Smart pointers will automatically clean up resources
 
-        for (const auto& _frame : _frames) {
-            // already written from before
-            vkDestroyCommandPool(_device, _frame._commandPool, nullptr);
-
-            // destroy sync objects
-            vkDestroyFence(_device, _frame._renderFence, nullptr);
-            vkDestroySemaphore(_device, _frame._renderSemaphore, nullptr);
-            vkDestroySemaphore(_device, _frame._swapchainSemaphore, nullptr);
+        for (auto& _frame : _frames) {
+            // Smart pointers automatically clean up sync objects
+            // Manual cleanup only for command pools and command buffers
+            if (_frame._commandPool) {
+                vkDestroyCommandPool(_device, _frame._commandPool->get(), nullptr);
+            }
+            
+            // Destroy frame descriptors manually
+            _frame._frameDescriptors.destroy_pools(_device);
         }
 
         destroy_swapchain();
@@ -602,6 +639,9 @@ void VulkanEngine::cleanup() {
 
         vkb::destroy_debug_utils_messenger(_instance, _debug_messenger);
         vkDestroyInstance(_instance, nullptr);
+
+        // VMA allocator cleanup
+        vmaDestroyAllocator(_allocator);
     }
 
     // clear engine pointer
@@ -694,10 +734,9 @@ GPUMeshBuffers VulkanEngine::uploadMesh(std::span<uint32_t> indices,
             },
             this);
 
-    _mainDeletionQueue.push_function(
-            [=, this] { destroy_buffer(newSurface.vertexBuffer); });
-    _mainDeletionQueue.push_function(
-            [=, this] { destroy_buffer(newSurface.indexBuffer); });
+    // Store mesh buffers in managed collections for automatic cleanup
+    _managedBuffers.push_back(std::make_unique<VulkanBuffer>(_allocator, newSurface.vertexBuffer));
+    _managedBuffers.push_back(std::make_unique<VulkanBuffer>(_allocator, newSurface.indexBuffer));
     destroy_buffer(staging);
 
     return newSurface;
@@ -739,10 +778,9 @@ void VulkanEngine::draw_geometry(VkCommandBuffer cmd) {
             sizeof(GPUSceneData), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
             VMA_MEMORY_USAGE_CPU_TO_GPU);
 
-    // add it to the deletion queue of this frame, so it gets deleted once it's
-    // been used
-    get_current_frame()._deletionQueue.push_function(
-            [=, this] { destroy_buffer(gpuSceneDataBuffer); });
+    // add it to the current frame's managed buffers for automatic cleanup
+    get_current_frame()._frameBuffers.push_back(
+        std::make_unique<VulkanBuffer>(_allocator, gpuSceneDataBuffer));
 
     // write the buffer
     auto* sceneUniformData =
@@ -760,7 +798,7 @@ void VulkanEngine::draw_geometry(VkCommandBuffer cmd) {
     writer.update_set(_device, globalDescriptor);
 
     VkRenderingAttachmentInfo colorAttachment = vkinit::attachment_info(
-            _drawImage.imageView, nullptr, VK_IMAGE_LAYOUT_GENERAL);
+            _drawImage->imageView(), nullptr, VK_IMAGE_LAYOUT_GENERAL);
 
     VkRenderingInfo renderInfo =
             vkinit::rendering_info(_drawExtent, &colorAttachment, nullptr);
@@ -791,7 +829,7 @@ void VulkanEngine::draw_geometry(VkCommandBuffer cmd) {
     VkDescriptorSet imageSet = get_current_frame()._frameDescriptors.allocate(
             _device, _singleImageDescriptorLayout);
     DescriptorWriter single_image_writer;
-    single_image_writer.write_image(0, _errorCheckerboardImage.imageView,
+    single_image_writer.write_image(0, _errorCheckerboardImage->imageView(),
                                     _defaultSamplerNearest,
                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
                                     VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
@@ -830,19 +868,20 @@ void VulkanEngine::draw() {
 
     // wait until the gpu has finished rendering the last frame. Timeout of 1
     // second
-    VK_CHECK(vkWaitForFences(_device, 1, &get_current_frame()._renderFence,
+    VK_CHECK(vkWaitForFences(_device, 1, get_current_frame()._renderFence->getPtr(),
                              true, 1000000000));
 
-    get_current_frame()._deletionQueue.flush();
+    // Clear frame buffers instead of flushing deletion queue
+    get_current_frame()._frameBuffers.clear();
     get_current_frame()._frameDescriptors.clear_pools(_device);
 
-    VK_CHECK(vkResetFences(_device, 1, &get_current_frame()._renderFence));
+    VK_CHECK(vkResetFences(_device, 1, get_current_frame()._renderFence->getPtr()));
 
     // request image from the swapchain
     uint32_t swapchainImageIndex;
     const VkResult e =
             vkAcquireNextImageKHR(_device, _swapchain, 1000000000,
-                                  get_current_frame()._swapchainSemaphore,
+                                  get_current_frame()._swapchainSemaphore->get(),
                                   nullptr, &swapchainImageIndex);
     if (e == VK_ERROR_OUT_OF_DATE_KHR) {
         resize_requested = true;
@@ -864,11 +903,11 @@ void VulkanEngine::draw() {
 
     _drawExtent.height = static_cast<uint32_t>(
             (float)std::min(_swapchainExtent.height,
-                            _drawImage.imageExtent.height) *
+                            _drawImage->get().imageExtent.height) *
             renderScale);
     _drawExtent.width = static_cast<uint32_t>(
             (float)std::min(_swapchainExtent.width,
-                            _drawImage.imageExtent.width) *
+                            _drawImage->get().imageExtent.width) *
             renderScale);
 
     VK_CHECK(vkBeginCommandBuffer(cmd, &cmdBeginInfo));
@@ -876,19 +915,19 @@ void VulkanEngine::draw() {
     // transition our main draw image into general layout, so we can write into
     // it, we will overwrite it all, so we don't care about what was the older
     // layout
-    vkutil::transition_image(cmd, _drawImage.image, VK_IMAGE_LAYOUT_UNDEFINED,
+    vkutil::transition_image(cmd, _drawImage->image(), VK_IMAGE_LAYOUT_UNDEFINED,
                              VK_IMAGE_LAYOUT_GENERAL);
 
     draw_background(cmd);
 
-    vkutil::transition_image(cmd, _drawImage.image, VK_IMAGE_LAYOUT_GENERAL,
+    vkutil::transition_image(cmd, _drawImage->image(), VK_IMAGE_LAYOUT_GENERAL,
                              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
     draw_geometry(cmd);
 
     // transition the draw image and the swapchain image into their correct
     // transfer layouts
-    vkutil::transition_image(cmd, _drawImage.image,
+    vkutil::transition_image(cmd, _drawImage->image(),
                              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
                              VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
     vkutil::transition_image(cmd, _swapchainImages[swapchainImageIndex],
@@ -896,7 +935,7 @@ void VulkanEngine::draw() {
                              VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     // execute a copy from the draw image into the swapchain
-    vkutil::copy_image_to_image(cmd, _drawImage.image,
+    vkutil::copy_image_to_image(cmd, _drawImage->image(),
                                 _swapchainImages[swapchainImageIndex],
                                 _drawExtent, _swapchainExtent);
 
@@ -927,10 +966,10 @@ void VulkanEngine::draw() {
 
     const VkSemaphoreSubmitInfo waitInfo = vkinit::semaphore_submit_info(
             VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR,
-            get_current_frame()._swapchainSemaphore);
+            get_current_frame()._swapchainSemaphore->get());
     const VkSemaphoreSubmitInfo signalInfo =
             vkinit::semaphore_submit_info(VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT,
-                                          get_current_frame()._renderSemaphore);
+                                          get_current_frame()._renderSemaphore->get());
 
     const VkSubmitInfo2 submit =
             vkinit::submit_info(&cmdinfo, &signalInfo, &waitInfo);
@@ -938,7 +977,7 @@ void VulkanEngine::draw() {
     // submit command buffer to the queue and execute it.
     //  _renderFence will now block until the graphic commands finish execution
     VK_CHECK(vkQueueSubmit2(_graphicsQueue, 1, &submit,
-                            get_current_frame()._renderFence));
+                            get_current_frame()._renderFence->get()));
 
     // prepare present
     //  this will put the image we just rendered to into the visible window.
@@ -951,7 +990,7 @@ void VulkanEngine::draw() {
     presentInfo.pSwapchains = &_swapchain;
     presentInfo.swapchainCount = 1;
 
-    presentInfo.pWaitSemaphores = &get_current_frame()._renderSemaphore;
+    presentInfo.pWaitSemaphores = get_current_frame()._renderSemaphore->getPtr();
     presentInfo.waitSemaphoreCount = 1;
 
     presentInfo.pImageIndices = &swapchainImageIndex;
@@ -1083,7 +1122,6 @@ void VulkanEngine::destroy_image(const AllocatedImage& img) const {
     vkDestroyImageView(_device, img.imageView, nullptr);
     vmaDestroyImage(_allocator, img.image, img.allocation);
 }
-
 
 void MeshNode::Draw(const glm::mat4& topMatrix, DrawContext& ctx) {
     const glm::mat4 nodeMatrix = topMatrix * worldTransform;

--- a/src/graphics/vulkan/vk_loader.cpp
+++ b/src/graphics/vulkan/vk_loader.cpp
@@ -288,7 +288,7 @@ std::optional<std::shared_ptr<LoadedGLTF>> loadGltf(VulkanEngine* engine,
     // load all textures
     images.reserve(gltf.images.size());
     for (size_t i = 0; i < gltf.images.size(); i++) {
-        images.push_back(engine->_errorCheckerboardImage);
+        images.push_back(engine->_errorCheckerboardImage->get());
     }
 
     // create buffer to hold the material data
@@ -324,9 +324,9 @@ std::optional<std::shared_ptr<LoadedGLTF>> loadGltf(VulkanEngine* engine,
 
         GLTFMetallic_Roughness::MaterialResources materialResources;
         // default the material textures
-        materialResources.colorImage = engine->_whiteImage;
+        materialResources.colorImage = engine->_whiteImage->get();
         materialResources.colorSampler = engine->_defaultSamplerLinear;
-        materialResources.metalRoughImage = engine->_whiteImage;
+        materialResources.metalRoughImage = engine->_whiteImage->get();
         materialResources.metalRoughSampler = engine->_defaultSamplerLinear;
 
         // set the uniform buffer for the material data

--- a/src/include/graphics/vulkan/vk_smart_wrappers.h
+++ b/src/include/graphics/vulkan/vk_smart_wrappers.h
@@ -1,0 +1,283 @@
+#pragma once
+
+#include <memory>
+#include <vulkan/vulkan_core.h>
+#include <vk_mem_alloc.h>
+#include "vk_types.h"
+
+class VulkanEngine;
+
+// RAII wrapper for VkFence
+class VulkanFence {
+public:
+    VulkanFence(VkDevice device, VkFence fence) : device_(device), fence_(fence) {}
+    
+    ~VulkanFence() {
+        if (fence_ != VK_NULL_HANDLE) {
+            vkDestroyFence(device_, fence_, nullptr);
+        }
+    }
+
+    // Move constructor and assignment
+    VulkanFence(VulkanFence&& other) noexcept 
+        : device_(other.device_), fence_(other.fence_) {
+        other.fence_ = VK_NULL_HANDLE;
+    }
+
+    VulkanFence& operator=(VulkanFence&& other) noexcept {
+        if (this != &other) {
+            if (fence_ != VK_NULL_HANDLE) {
+                vkDestroyFence(device_, fence_, nullptr);
+            }
+            device_ = other.device_;
+            fence_ = other.fence_;
+            other.fence_ = VK_NULL_HANDLE;
+        }
+        return *this;
+    }
+
+    // Delete copy constructor and assignment
+    VulkanFence(const VulkanFence&) = delete;
+    VulkanFence& operator=(const VulkanFence&) = delete;
+
+    VkFence get() const { return fence_; }
+    VkFence* getPtr() { return &fence_; }
+    operator VkFence() const { return fence_; }
+
+private:
+    VkDevice device_;
+    VkFence fence_ = VK_NULL_HANDLE;
+};
+
+// RAII wrapper for VkSemaphore
+class VulkanSemaphore {
+public:
+    VulkanSemaphore(VkDevice device, VkSemaphore semaphore) : device_(device), semaphore_(semaphore) {}
+    
+    ~VulkanSemaphore() {
+        if (semaphore_ != VK_NULL_HANDLE) {
+            vkDestroySemaphore(device_, semaphore_, nullptr);
+        }
+    }
+
+    // Move constructor and assignment
+    VulkanSemaphore(VulkanSemaphore&& other) noexcept 
+        : device_(other.device_), semaphore_(other.semaphore_) {
+        other.semaphore_ = VK_NULL_HANDLE;
+    }
+
+    VulkanSemaphore& operator=(VulkanSemaphore&& other) noexcept {
+        if (this != &other) {
+            if (semaphore_ != VK_NULL_HANDLE) {
+                vkDestroySemaphore(device_, semaphore_, nullptr);
+            }
+            device_ = other.device_;
+            semaphore_ = other.semaphore_;
+            other.semaphore_ = VK_NULL_HANDLE;
+        }
+        return *this;
+    }
+
+    // Delete copy constructor and assignment
+    VulkanSemaphore(const VulkanSemaphore&) = delete;
+    VulkanSemaphore& operator=(const VulkanSemaphore&) = delete;
+
+    VkSemaphore get() const { return semaphore_; }
+    VkSemaphore* getPtr() { return &semaphore_; }
+    operator VkSemaphore() const { return semaphore_; }
+
+private:
+    VkDevice device_;
+    VkSemaphore semaphore_ = VK_NULL_HANDLE;
+};
+
+// RAII wrapper for VkCommandPool
+class VulkanCommandPool {
+public:
+    VulkanCommandPool(VkDevice device, VkCommandPool commandPool) : device_(device), commandPool_(commandPool) {}
+    
+    ~VulkanCommandPool() {
+        if (commandPool_ != VK_NULL_HANDLE) {
+            vkDestroyCommandPool(device_, commandPool_, nullptr);
+        }
+    }
+
+    // Move constructor and assignment
+    VulkanCommandPool(VulkanCommandPool&& other) noexcept 
+        : device_(other.device_), commandPool_(other.commandPool_) {
+        other.commandPool_ = VK_NULL_HANDLE;
+    }
+
+    VulkanCommandPool& operator=(VulkanCommandPool&& other) noexcept {
+        if (this != &other) {
+            if (commandPool_ != VK_NULL_HANDLE) {
+                vkDestroyCommandPool(device_, commandPool_, nullptr);
+            }
+            device_ = other.device_;
+            commandPool_ = other.commandPool_;
+            other.commandPool_ = VK_NULL_HANDLE;
+        }
+        return *this;
+    }
+
+    // Delete copy constructor and assignment
+    VulkanCommandPool(const VulkanCommandPool&) = delete;
+    VulkanCommandPool& operator=(const VulkanCommandPool&) = delete;
+
+    VkCommandPool get() const { return commandPool_; }
+    VkCommandPool* getPtr() { return &commandPool_; }
+    operator VkCommandPool() const { return commandPool_; }
+
+private:
+    VkDevice device_;
+    VkCommandPool commandPool_ = VK_NULL_HANDLE;
+};
+
+// RAII wrapper for VkImageView
+class VulkanImageView {
+public:
+    VulkanImageView(VkDevice device, VkImageView imageView) : device_(device), imageView_(imageView) {}
+    
+    ~VulkanImageView() {
+        if (imageView_ != VK_NULL_HANDLE) {
+            vkDestroyImageView(device_, imageView_, nullptr);
+        }
+    }
+
+    // Move constructor and assignment
+    VulkanImageView(VulkanImageView&& other) noexcept 
+        : device_(other.device_), imageView_(other.imageView_) {
+        other.imageView_ = VK_NULL_HANDLE;
+    }
+
+    VulkanImageView& operator=(VulkanImageView&& other) noexcept {
+        if (this != &other) {
+            if (imageView_ != VK_NULL_HANDLE) {
+                vkDestroyImageView(device_, imageView_, nullptr);
+            }
+            device_ = other.device_;
+            imageView_ = other.imageView_;
+            other.imageView_ = VK_NULL_HANDLE;
+        }
+        return *this;
+    }
+
+    // Delete copy constructor and assignment
+    VulkanImageView(const VulkanImageView&) = delete;
+    VulkanImageView& operator=(const VulkanImageView&) = delete;
+
+    VkImageView get() const { return imageView_; }
+    VkImageView* getPtr() { return &imageView_; }
+    operator VkImageView() const { return imageView_; }
+
+private:
+    VkDevice device_;
+    VkImageView imageView_ = VK_NULL_HANDLE;
+};
+
+// RAII wrapper for AllocatedBuffer
+class VulkanBuffer {
+public:
+    VulkanBuffer(VmaAllocator allocator, const AllocatedBuffer& buffer) 
+        : allocator_(allocator), buffer_(buffer) {}
+    
+    ~VulkanBuffer() {
+        if (buffer_.buffer != VK_NULL_HANDLE) {
+            vmaDestroyBuffer(allocator_, buffer_.buffer, buffer_.allocation);
+        }
+    }
+
+    // Move constructor and assignment
+    VulkanBuffer(VulkanBuffer&& other) noexcept 
+        : allocator_(other.allocator_), buffer_(other.buffer_) {
+        other.buffer_.buffer = VK_NULL_HANDLE;
+        other.buffer_.allocation = nullptr;
+    }
+
+    VulkanBuffer& operator=(VulkanBuffer&& other) noexcept {
+        if (this != &other) {
+            if (buffer_.buffer != VK_NULL_HANDLE) {
+                vmaDestroyBuffer(allocator_, buffer_.buffer, buffer_.allocation);
+            }
+            allocator_ = other.allocator_;
+            buffer_ = other.buffer_;
+            other.buffer_.buffer = VK_NULL_HANDLE;
+            other.buffer_.allocation = nullptr;
+        }
+        return *this;
+    }
+
+    // Delete copy constructor and assignment
+    VulkanBuffer(const VulkanBuffer&) = delete;
+    VulkanBuffer& operator=(const VulkanBuffer&) = delete;
+
+    const AllocatedBuffer& get() const { return buffer_; }
+    VkBuffer buffer() const { return buffer_.buffer; }
+    VmaAllocation allocation() const { return buffer_.allocation; }
+
+private:
+    VmaAllocator allocator_;
+    AllocatedBuffer buffer_{};
+};
+
+// RAII wrapper for AllocatedImage
+class VulkanImage {
+public:
+    VulkanImage(VmaAllocator allocator, VkDevice device, const AllocatedImage& image) 
+        : allocator_(allocator), device_(device), image_(image) {}
+    
+    ~VulkanImage() {
+        if (image_.imageView != VK_NULL_HANDLE) {
+            vkDestroyImageView(device_, image_.imageView, nullptr);
+        }
+        if (image_.image != VK_NULL_HANDLE) {
+            vmaDestroyImage(allocator_, image_.image, image_.allocation);
+        }
+    }
+
+    // Move constructor and assignment
+    VulkanImage(VulkanImage&& other) noexcept 
+        : allocator_(other.allocator_), device_(other.device_), image_(other.image_) {
+        other.image_.image = VK_NULL_HANDLE;
+        other.image_.imageView = VK_NULL_HANDLE;
+        other.image_.allocation = nullptr;
+    }
+
+    VulkanImage& operator=(VulkanImage&& other) noexcept {
+        if (this != &other) {
+            if (image_.imageView != VK_NULL_HANDLE) {
+                vkDestroyImageView(device_, image_.imageView, nullptr);
+            }
+            if (image_.image != VK_NULL_HANDLE) {
+                vmaDestroyImage(allocator_, image_.image, image_.allocation);
+            }
+            allocator_ = other.allocator_;
+            device_ = other.device_;
+            image_ = other.image_;
+            other.image_.image = VK_NULL_HANDLE;
+            other.image_.imageView = VK_NULL_HANDLE;
+            other.image_.allocation = nullptr;
+        }
+        return *this;
+    }
+
+    // Delete copy constructor and assignment
+    VulkanImage(const VulkanImage&) = delete;
+    VulkanImage& operator=(const VulkanImage&) = delete;
+
+    const AllocatedImage& get() const { return image_; }
+    VkImage image() const { return image_.image; }
+    VkImageView imageView() const { return image_.imageView; }
+    VmaAllocation allocation() const { return image_.allocation; }
+
+private:
+    VmaAllocator allocator_;
+    VkDevice device_;
+    AllocatedImage image_{};
+};
+
+// Factory functions for creating smart pointers
+template<typename T, typename... Args>
+std::unique_ptr<T> make_vulkan_unique(Args&&... args) {
+    return std::make_unique<T>(std::forward<Args>(args)...);
+}


### PR DESCRIPTION
Replace raw Vulkan handles with smart wrapper classes for automatic resource management. Updates command pools, images, and fences to use RAII pattern, eliminating manual cleanup code and reducing memory leaks.