### PR TITLE
feat: added packages versions

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -29,6 +29,38 @@
     {
       "name": "fastgltf",
       "version": "0.7.1"
+    },
+    {
+      "name": "flecs",
+      "version": "4.0.2"
+    },
+    {
+      "name": "gtest",
+      "version": "1.15.2"
+    },
+    {
+      "name": "imgui",
+      "version": "1.91.0"
+    },
+    {
+      "name": "sdl2",
+      "version": "2.30.8"
+    },
+    {
+      "name": "simdjson",
+      "version": "3.10.1"
+    },
+    {
+      "name": "spdlog",
+      "version": "1.14.1"
+    },
+    {
+      "name": "vulkan-headers",
+      "version": "1.3.290.0#1"
+    },
+    {
+      "name": "vulkan-loader",
+      "version": "1.3.290.0"
     }
   ]
 }


### PR DESCRIPTION
При попытке сбилдить проект получаем ошибки вида:

```
-- Running vcpkg install
error: no version database entry for **<package>** at **<version>**.
Available versions:
 **<versions>**
 ```
 
 Ошибка возникает, потому что указан довольно старый _builtin-baseline_ и _vcpkg_ не может найти новые версии соответствующий пакетов. Добавил конкретные версии для каждого недостающего пакета.
